### PR TITLE
Update ironic update for a variable number of ceph nodes

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -25,8 +25,9 @@ fi
 
 if [ $IRONIC -eq 1 ]; then
     echo "Updating ironic ceph nodes with ceph-storage profiles"
-    for i in $(seq 0 2); do 
-	ironic node-update ceph-$i replace properties/capabilities=profile:ceph-storage,boot_option:local
+    for i in `openstack baremetal node list | grep ceph | awk '{print $2}'`
+    do
+	ironic node-update $i replace properties/capabilities=profile:ceph-storage,boot_option:local
     done
 fi
 


### PR DESCRIPTION
init.sh was hardcoded for 3 ceph nodes needing ironic updates.
This changes will update any number of ceph nodes (ie: 1 line me).
Danger: it will update any node string with 'ceph'. Hopefully it
will not show up in the uuid string.